### PR TITLE
Added ability to set Edge Name (Label) and Tooltip Text (Title).

### DIFF
--- a/NetworkGraph/src/main/java/de/elomagic/vaadin/addon/networkgraph/Edge.java
+++ b/NetworkGraph/src/main/java/de/elomagic/vaadin/addon/networkgraph/Edge.java
@@ -23,6 +23,8 @@ package de.elomagic.vaadin.addon.networkgraph;
 public final class Edge {
     private String from;
     private String to;
+    private String title;
+    private String label;
     private Style style = Style.line;
     private String color = "";
     private int length;
@@ -135,6 +137,42 @@ public final class Edge {
      */
     public void setLength(final int length) {
         this.length = length;
+    }
+
+    /**
+     * Returns the title of the edge. (Tooltip Text seen on mouseover)
+     *
+     * @return title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Set the title of the edge. (Tooltip Text seen on mouseover)
+     *
+     * @param title
+     */
+    public void setTitle(final String title) {
+        this.title = title;
+    }
+
+    /**
+     * Returns the label of the edge.
+     *
+     * @return label
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Set the label of the edge.
+     *
+     * @param label
+     */
+    public void setLabel(final String label) {
+        this.label = label;
     }
 
     public static enum Style {


### PR DESCRIPTION
Added ability to set Edge Name (Label) and Tooltip Text (Title). This was simple to implement since Vis already had this functionality built-in, network-graph just needed to access it.

This will close issue #3.
